### PR TITLE
Allow Labels on Log Records

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -1,15 +1,18 @@
 from flask import Flask
 import logging
+from flask import g
 
 from owslogger import logger
 
-
 app = Flask(__name__)
-logger.setup(app, None, 'dev', 'logger_name', logging.INFO, 'service_name', '1.0.0')
+logger.setup(
+    app, 'https://logglyurl', 'dev', 'logger_name', logging.INFO,
+    'service_name', '1.0.0')
 
 
 @app.route('/')
 def home():
+    g.log.warning('something', resources={'upc': 'awesome'})
     return 'Home'
 
 if __name__ == '__main__':


### PR DESCRIPTION
To be able to trace effectively systems that have impacted a specific
label, upc, isrc, subaccount (or other types of entities), we need to
be able to pass in a field to labelize the logs.

```python
g.log.warning('something', labels={'upc': 'awesome'})
```

@jessmchung